### PR TITLE
Set fromRepo property only if provided and after read settings file.

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
@@ -320,10 +320,12 @@ public class GitChangelogTask extends DefaultTask {
       GitChangelogApi builder;
       builder = gitChangelogApiBuilder();
 
-      builder.withFromRepo(fromRepo);
-
       if (isSupplied(settingsFile)) {
         builder.withSettings(getProject().file(settingsFile).toURI().toURL());
+      }
+
+      if (isSupplied(fromRepo)) {
+        builder.withFromRepo(fromRepo);
       }
 
       if (isSupplied(toRef)) {


### PR DESCRIPTION
This will provide ability to override path to git repo from gradle script.

Use case:
- If you execute plugin on OpenJDK11+ with daemon relative path `"fromRepo": ".",` will be resolved into path to daemon executable folder like this `/your/home/folder/.gradle/daemon/5.4.1/.`
- As described in #15 you can fix it by set it from gradle script like this
```
fromRepo = file("$projectDir")
```
- But it will be overwritten if you use settings file like this 
```
settingsFile = rootProject.file("changelog.json").getAbsolutePath()
```

This PR will make behavior `fromRepo` property same as others.

Than finally we can use it like this
```
    fromRepo = file("$projectDir")
    settingsFile = rootProject.file("changelog.json").getAbsolutePath()
    file = new File("CHANGELOG.md")
```
Hope this is right solution. If not please suggest how to fix it properly.
Thanks.