### PR TITLE
docs(README.md): how to configure the default branch (master -> main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ task gitChangelogTask(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask
   """;
 }
 ```
+### Edge case usage
+#### When your default branch is not `master`, use `toRef = $BRANCH_NAME`.
+
+If `toIdOpt.isPresent()` is NULL, `toId` is set to the master branch as `toId = gitRepo.getRef(REF_MASTER)` in GitChangelogApi.java so specify `toRef` by providing the branch name you'd like to base in.
+```kotlin
+// Kotlin 
+tasks.create<se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask>("gitChangelogTask") {
+    file = File("CHANGELOG.md")
+    fromRepo = File("$projectDir").toString()
+    toRef = "main"
+    templateContent = """
+      // Template here!    
+    """
+}
+```
 
 ### Get next release
 


### PR DESCRIPTION
Adding some documentation on how to configure Gradle tasks when the default branch is "main" not "master" 

- Relevant issues: 
https://github.com/tomasbjerre/git-changelog-lib/issues/100#issuecomment-872049758,
https://github.com/tomasbjerre/git-changelog-gradle-plugin/issues/24

 
