### PR TITLE
feat: Add root gradle project as default git repository directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ git-changelog-gradle-plugin-example/whatever/
 .classpath
 .project
 .settings
+.idea
 generated-src
 build
 target

--- a/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
@@ -17,7 +17,7 @@ public class GitChangelogTask extends DefaultTask {
 
   private static final Logger log = LoggerFactory.getLogger(GitChangelogTask.class.getName());
 
-  public String fromRepo;
+  public String fromRepo = this.getProject().getRootProject().getRootDir().getAbsolutePath();
 
   public String toRef;
   public String toCommit;


### PR DESCRIPTION
This should remove the need of the hack `fromRepo = new File(".")` mentioned in #15.
Most of the projects have the root gradle project as the root git repository