### PR TITLE
fix: Set repo for GitChangelogSemanticVersionTask

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogSemanticVersionTask.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogSemanticVersionTask.java
@@ -28,6 +28,7 @@ public class GitChangelogSemanticVersionTask extends DefaultTask {
   public void gitChangelogPluginTasks() throws TaskExecutionException {
     try {
       final GitChangelogApi gitChangelogApiBuilder = gitChangelogApiBuilder();
+      gitChangelogApiBuilder.withFromRepo(this.getProject().getRootDir());
       if (this.isSupplied(this.majorVersionPattern)) {
         gitChangelogApiBuilder.withSemanticMajorVersionPattern(this.majorVersionPattern);
       }


### PR DESCRIPTION
Without this fix I only get `se.bjurr.gitchangelog.api.exceptions.GitChangelogRepositoryException: Did not find a GIT repo in C:\Users\simon\.gradle\daemon\7.6\.`