### PR TITLE
feat: Move file default to task

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogGradlePlugin.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogGradlePlugin.java
@@ -12,7 +12,6 @@ public class GitChangelogGradlePlugin implements Plugin<Project> {
 
     final GitChangelogTask gitChangelogTask =
         target.getTasks().create("gitChangelog", GitChangelogTask.class);
-    gitChangelogTask.file = target.getRootProject().file("CHANGELOG.md");
     gitChangelogTask.ignoreCommitsIfMessageMatches =
         "^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*|.*\\[GRADLE SCRIPT\\].*";
   }

--- a/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/gradle/GitChangelogTask.java
@@ -29,7 +29,7 @@ public class GitChangelogTask extends DefaultTask {
   public String templateBaseDir;
   public String templateContent;
   public String templateSuffix;
-  public File file;
+  public File file = this.getProject().file("CHANGELOG.md");
 
   public String readableTagName;
   public String dateFormat;


### PR DESCRIPTION
It makes sense to have it as default. Otherwise no changelog would get generated with configs like this
```
task gitChangelogTask(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
 templateContent = """
  // Template here!
 """;
}
```
because the file isn't set